### PR TITLE
add extended installation information

### DIFF
--- a/chapters/00-intro.md
+++ b/chapters/00-intro.md
@@ -130,7 +130,7 @@ and then follow these three steps.
    * The `extension_dir` configuration directive in `php.ini` will point you in the right place
 3. Add `extension=php_libsodium.dll` to your `php.ini` file.
 
-#### Installing Libsodium (from source)
+<h4 id="installing-libsodium-source">Installing Libsodium (from source)</h4>
 
 If you're wanting the latest release of libsodium and it hasn't yet made its
 way into your operating system's package management repositories, the best

--- a/chapters/00-intro.md
+++ b/chapters/00-intro.md
@@ -146,7 +146,7 @@ install libsodium from source.
 
 Debian-based distributions can install the necessary utilities with:
 
-    apt-get install autoconf build-essential libtool
+    apt-get install build-essential
 
 RHEL-based distributions can install the necessary utilities with:
 
@@ -155,12 +155,9 @@ RHEL-based distributions can install the necessary utilities with:
 After installing the necessary utilities, libsodium can be compiled as such:
 
     # Clone the libsodium source tree
-    git clone https://github.com/jedisct1/libsodium.git; cd libsodium
-    # Switch to the latest release of libsodium
-    git checkout "$(git for-each-ref --sort=taggerdate \
-      --format='tags/%(tag)' | tail -1)"
+    git clone -b stable https://github.com/jedisct1/libsodium.git
     # Build libsodium, perform any defined tests, install libsodium
-    ./autogen.sh && ./configure && make check && make install
+    cd libsodium && ./configure && make check && make install
 
 ---------------------------
 
@@ -212,15 +209,7 @@ script:
 
 If you get different numbers, you won't have access to some of the features that
 should be in libsodium 1.0.10. If you need them, you'll need to go through the
-ritual of compiling from source instead:
-
-    sudo apt-get purge libsodium1.* # get rid of distro packages
-    git clone https://github.com/jedisct1/libsodium.git
-    cd libsodium
-    git checkout tags/1.0.10
-    ./autogen.sh
-    ./configure && make distcheck
-    sudo make install
+ritual of compiling from source instead (shown above).
 
 Then run `pecl uninstall libsodium` and `pecl install libsodium`. When you run
 the version check PHP script again, you should see the correct numbers.

--- a/chapters/00-intro.md
+++ b/chapters/00-intro.md
@@ -85,7 +85,7 @@ and and understood [basic cryptography concepts](https://paragonie.com/blog/2015
 
 <h3 id="installing-libsodium">Installing Libsodium and the PHP extension</h3>
 
-#### Installing Libsodium
+#### Installing Libsodium (precompiled)
 
 On Debian >= 8 and Ubuntu >= 15.04, libsodium can be installed with:
 
@@ -130,10 +130,39 @@ and then follow these three steps.
    * The `extension_dir` configuration directive in `php.ini` will point you in the right place
 3. Add `extension=php_libsodium.dll` to your `php.ini` file.
 
----------------------------
+#### Installing Libsodium (from source)
 
-If your operating system (or OS version) isn't listed above, you may have to go
-through the trouble of [manually installing libsodium](https://download.libsodium.org/doc/installation/index.html).
+If you're wanting the latest release of libsodium and it hasn't yet made its
+way into your operating system's package management repositories, the best
+option is to compile it from source.
+
+Installing libsodium from source on OS X is easy; simply provide the
+`--build-from-source` flag when installing with brew:
+
+    brew install --build-from-source libsodium
+
+For other operating systems, some prerequisites are necessary to build and
+install libsodium from source.
+
+Debian-based distributions can install the necessary utilities with:
+
+    apt-get install autoconf build-essential libtool
+
+RHEL-based distributions can install the necessary utilities with:
+
+    yum groupinstall "Development Tools"
+
+After installing the necessary utilities, libsodium can be compiled as such:
+
+    # Clone the libsodium source tree
+    git clone https://github.com/jedisct1/libsodium.git; cd libsodium
+    # Switch to the latest release of libsodium
+    git checkout "$(git for-each-ref --sort=taggerdate \
+      --format='tags/%(tag)' | tail -1)"
+    # Build libsodium, perform any defined tests, install libsodium
+    ./autogen.sh && ./configure && make check && make install
+
+---------------------------
 
 #### Installing the PHP Extension via PECL
 


### PR DESCRIPTION
I've made a few adaptations to the installation portion of the documentation that will hopefully make their way to the [PECL libsodium book](https://paragonie.com/book/pecl-libsodium). If so, I'll be working on submitting revisions to the Halite documentation as well that will coincide with this set of revisions.
