### PR TITLE
Fix return typehint

### DIFF
--- a/chapters/08-advanced.md
+++ b/chapters/08-advanced.md
@@ -236,7 +236,7 @@ This will encrypt a message with a user's public key.
 
 #### Sealed Box Decryption
 
-> `string \Sodium\crypto_box_seal_open(string $message, string $recipient_keypair)`
+> `string|bool \Sodium\crypto_box_seal_open(string $message, string $recipient_keypair)`
 
 Opens a sealed box with a keypair from your secret key and public key.
 
@@ -248,6 +248,9 @@ Opens a sealed box with a keypair from your secret key and public key.
         $anonymous_message_to_bob,
         $bob_box_kp
     );
+    if ($decrypted_message === false) {
+        throw new Exception("Bad ciphertext");
+    }
 
 <h3 id="crypto-scalarmult">Scalar multiplication (Elliptic Curve Cryptography)</h3>
 


### PR DESCRIPTION
`crypto_box_seal_open` can fail with `false`, e.g.

<img width="822" alt="screen shot 2017-08-01 at 21 21 42" src="https://user-images.githubusercontent.com/3288888/28845512-398b2c40-7700-11e7-965f-b677e3dd894a.png">