### PR TITLE
Hashing: report BLAKE2b usage from libsodium

### DIFF
--- a/chapters/06-hashing.md
+++ b/chapters/06-hashing.md
@@ -57,6 +57,15 @@ Examples:
     sodium_crypto_generichash_update($state, 'message part 2');
     $h = sodium_crypto_generichash_final(64);
 
+#### Notes
+
+The `sodium_crypto_generichash_*` function set is implemented using BLAKE2b, a
+simple, standardized ([RFC 7693](https://www.rfc-editor.org/rfc/rfc7693.txt))
+secure hash function that is as strong as SHA-3 but faster than SHA-1 and MD5.
+
+Unlike MD5, SHA-1 and SHA-256, this function is safe against hash length
+extension attacks.
+
 <h3 id="crypto-shorthash">Short Hashing</h3>
 
 > `string sodium_crypto_shorthash(string $message, string $key)`


### PR DESCRIPTION
Hi, to me it isn't clear enough that `generichash` uses BLAKE2b algorithms.

I think this it's worth to mention it, like the [libsodium docs does](https://download.libsodium.org/doc/hashing/generic_hashing#notes).