### PR TITLE
Update 05-publickey-crypto.md

### DIFF
--- a/chapters/05-publickey-crypto.md
+++ b/chapters/05-publickey-crypto.md
@@ -75,7 +75,7 @@ binary string that should only be used once).
         $alice_box_secretkey,
         $bob_box_publickey
     );
-    $message_nonce = random_bytes(SODIUM_CRYPTO_BOX_NONCEBYTES);
+    $nonce = random_bytes(SODIUM_CRYPTO_BOX_NONCEBYTES);
     $ciphertext = sodium_crypto_box(
         $message,
         $nonce,


### PR DESCRIPTION
The variable `$nonce` is subsequently used, not `$message_nonce`.